### PR TITLE
Update merge to fix security vulnerability.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "path-to-regexp": "0.1.x",
-    "merge": "~1.1.2",
+    "merge": ">=2.1.1",
     "zip-object": "~0.1.0",
     "clone": "~0.1.11"
   }


### PR DESCRIPTION
Merge has a high risk security vulnerability open. This was patched in version of merge more recent than 2.1.1. NPM advisory here https://www.npmjs.com/advisories/1666